### PR TITLE
Fix steamline tags for CI

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: default
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   build:
+    runs-on: self-hosted
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/helm-push.yaml
+++ b/.github/workflows/helm-push.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   push:
-    runs-on: self-hosted
+    runs-on: default
     steps:
       - uses: actions/checkout@v1
       - name: Helm Push Action

--- a/.github/workflows/helm-push.yaml
+++ b/.github/workflows/helm-push.yaml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   push:
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v1
       - name: Helm Push Action

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,6 +15,7 @@ on:
 jobs:
   Lint:
     name: lint
+    runs-on: self-hosted
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,7 +15,7 @@ on:
 jobs:
   Lint:
     name: lint
-    runs-on: self-hosted
+    runs-on: default
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3


### PR DESCRIPTION
Due to a mistaken understanding of what runs-on actually would do if removed we have managed to break our pipelines by removing the runs-on: default. This PR reverts the changes to remove runs-on: default and runs-on: self-hosted and makes sure that we only use runs-on: default.